### PR TITLE
 Update staging deployment workflow to trigger on main branch

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,7 +3,7 @@ name: Deploy to Staging
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
#  Summary

  - Updated GitHub Actions staging deployment workflow to trigger on main branch instead of master
  - Aligns staging deployment with the repository's primary branch naming convention

#  Changes

  - Modified .github/workflows/deploy-staging.yml to trigger on main branch pushes instead of master

#  Test plan

  - Verify workflow triggers correctly when merging to main branch
  - Confirm staging deployment completes successfully with self-hosted runner
  - Test that workflow does not trigger on other branches
